### PR TITLE
[WIP]Add deoplete source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .phpcd/
 /vimunit
 composer.lock
+
+# Ignore deoplete source cache
+*.py[cod]

--- a/rplugin/python3/deoplete/sources/phpcd.py
+++ b/rplugin/python3/deoplete/sources/phpcd.py
@@ -15,8 +15,8 @@ class Source(Base):
 
     def get_complete_position(self, context):
         return self.vim.call('phpcd#CompletePHP',
-                             1, '', 0)
+                             1, '')
 
     def gather_candidates(self, context):
         return self.vim.call('phpcd#CompletePHP',
-                             0, context['complete_str'], 0)
+                             0, context['complete_str'])

--- a/rplugin/python3/deoplete/sources/phpcd.py
+++ b/rplugin/python3/deoplete/sources/phpcd.py
@@ -1,0 +1,22 @@
+from .base import Base
+
+class Source(Base):
+    def __init__(self, vim):
+        Base.__init__(self, vim)
+
+        self.name = 'phpcd'
+        self.mark = '[php]'
+        self.filetypes = ['php']
+        self.is_bytepos = True
+        self.input_pattern = '[^. \t0-9]\.\w*'
+        self.rank = 500
+        self.max_pattern_length = -1
+        self.matchers = ['matcher_full_fuzzy']
+
+    def get_complete_position(self, context):
+        return self.vim.call('phpcd#CompletePHP',
+                             1, '', 0)
+
+    def gather_candidates(self, context):
+        return self.vim.call('phpcd#CompletePHP',
+                             0, context['complete_str'], 0)


### PR DESCRIPTION
we should test with the setting below:
```viml
let g:deoplete#omni#input_patterns = get(g:,'deoplete#omni#input_patterns',{})
let g:deoplete#omni#input_patterns.php = '\h\w*\|[^. \t]->\%(\h\w*\)\?\|\h\w*::\%(\h\w*\)\?'
let g:deoplete#ignore_sources = get(g:, 'deoplete#ignore_sources', {})
" in neovim we should disable omni source for php
let g:deoplete#ignore_sources.php = ['omni']
" if you want to hide `[php]` in the popupmenu, set mark as empty.
call deoplete#custom#set('phpcd', 'mark', '')
```



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/php-vim/phpcd.vim/69)
<!-- Reviewable:end -->
