### PR TITLE
Return value for PHPCD::info() should be an empty array

### DIFF
--- a/php/PHPCD.php
+++ b/php/PHPCD.php
@@ -539,7 +539,7 @@ class PHPCD implements RpcHandler
             return $items;
         } catch (\ReflectionException $e) {
             $this->logger->debug($e->getMessage());
-            return [null, []];
+            return [];
         }
     }
 


### PR DESCRIPTION
The omnifunc should receive an empty array when no results are found. (see: http://vimdoc.sourceforge.net/htmldoc/insert.html#complete-functions)

This was causing a 'using list as a string' error in vim, this was due to the second argument being an array. Also leaving the null in the array causes the omnifunc to output 'v:null' while an empty list just won't show anything like it should